### PR TITLE
Remove 'wgVersion' from cached variable list

### DIFF
--- a/src/js/Global.ts
+++ b/src/js/Global.ts
@@ -21,7 +21,6 @@ export default class Global
 		"wgServer",
 		"wgScriptPath",
 		"wgMonthNames",
-		"wgVersion",
 	]);
 	static userOptions						: any; // Unlike config user data potentially needs to be loaded first.
 	static readonly debug					: boolean = Global.config.debug || mw.util.getParamValue("useuserjs")=="0" || mw.util.getParamValue("safemode")=="1";


### PR DESCRIPTION
This script doesn't make use of 'wgVersion', so it can be removed from the config variables list. I've been cleaning up now-unneeded backward-compatibility-related stuff from lots of Dev Wiki scripts, and this is one of the last ones.